### PR TITLE
Don't send duplicate time.

### DIFF
--- a/processCommands.c
+++ b/processCommands.c
@@ -52,6 +52,23 @@ void processCommands() {
 //
 //---------------------------------------------------------------------
 
+char last_time[512];
 
+if( page == 0 )
+	{
+	if( strstr( TXbuffer, "t2.txt=" ) > 0 )
+		{
+		if( strcmp( TXbuffer, last_time ) == 0 )
+			{
+			TXbuffer[0] = 0;
+			}
+		else
+			{
+			sprintf( last_time, "%s", TXbuffer );
+			}
+		}
+
+
+	}
 }
 


### PR DESCRIPTION
This change keeps track of the last time of day that was sent
to display and prevents sending the time of day to the display
if it hasn't changed.  This reduces the amount of information
that gets sent to the display.