### PR TITLE
Add install to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,9 @@ NextionDriver:
 
 clean:
 		$(RM) NextionDriver *.o *.d *.bak *~
+
+install:
+		sudo service mmdvmhost stop
+		sudo cp NextionDriver /usr/local/bin
+		sudo service mmdvmhost restart
+


### PR DESCRIPTION
Added an install option to the Makefile to make it easy to test
changes.  Running "make install" will turn off the mmdvmhost
service, copy the NextionDriver, and restart the service.